### PR TITLE
Direct the `repo_url` to the fcitx5-android repository

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,11 +17,13 @@ theme:
     - navigation.top
 site_url: https://fcitx5-android.github.io
 
+repo_name: fcitx5-android
+repo_url: https://github.com/fcitx5-android/fcitx5-android
+
 nav:
   - 主页: index.md
   - 安装: installation.md
   - 常见问题: faq.md
-repo_url: https://github.com/fcitx5-android/fcitx5-android.github.io
 
 markdown_extensions:
   - toc:


### PR DESCRIPTION
... instead of this doc repository.

Also put the `repo_*` sections on the top of the `nav` section to prevent future growing navigation table from affecting the "visibility" of them.